### PR TITLE
upgrade to MM 5, fix login/respawn listener, & comment out code that causes console spam

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,9 +67,9 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>io.lumine.xikage</groupId>
-			<artifactId>MythicMobs</artifactId>
-			<version>4.8.0</version>
+			<groupId>io.lumine</groupId>
+			<artifactId>Mythic-Dist</artifactId>
+			<version>5.0.3</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/com/gmail/sharpcastle33/did/listeners/MobSpawnManager.java
+++ b/src/main/java/com/gmail/sharpcastle33/did/listeners/MobSpawnManager.java
@@ -4,10 +4,12 @@ import com.gmail.sharpcastle33.did.DescentIntoDarkness;
 import com.gmail.sharpcastle33.did.config.MobSpawnEntry;
 import com.gmail.sharpcastle33.did.instancing.CaveTracker;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
-import io.lumine.xikage.mythicmobs.MythicMobs;
-import io.lumine.xikage.mythicmobs.adapters.bukkit.BukkitAdapter;
-import io.lumine.xikage.mythicmobs.api.bukkit.events.MythicMobSpawnEvent;
-import io.lumine.xikage.mythicmobs.mobs.ActiveMob;
+
+import io.lumine.mythic.bukkit.MythicBukkit;
+import io.lumine.mythic.bukkit.BukkitAdapter;
+import io.lumine.mythic.bukkit.events.MythicMobSpawnEvent;
+import io.lumine.mythic.core.mobs.ActiveMob;
+
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.OfflinePlayer;
@@ -93,7 +95,6 @@ public class MobSpawnManager implements Runnable, Listener {
 			}
 		}
 
-
 		// Pick a random distance between minDistance and maxDistance, then a random point on the sphere with that radius.
 		// Makes distances uniformly likely, as opposed to
 		Vector spawnLocation = new Vector(rand.nextGaussian(), rand.nextGaussian(), rand.nextGaussian())
@@ -108,15 +109,29 @@ public class MobSpawnManager implements Runnable, Listener {
 
 		// quick exit for the blocks the mob will definitely intersect, and respect custom hitbox
 		if (spawnEntry.getXSize() > 0 && spawnEntry.getYSize() > 0 && spawnEntry.getZSize() > 0) {
-			if (!canSpawnMob(cave.getWorld(), spawnEntry,
-					spawnLocation.getX() - spawnEntry.getXSize() / 2, spawnLocation.getY(), spawnLocation.getZ() - spawnEntry.getZSize() / 2,
-					spawnLocation.getX() + spawnEntry.getXSize() / 2, spawnLocation.getY() + spawnEntry.getYSize(), spawnLocation.getZ() + spawnEntry.getZSize() / 2)) {
+			if (!canSpawnMob(
+				cave.getWorld(),
+				spawnEntry,
+				spawnLocation.getX() - spawnEntry.getXSize() / 2,
+				spawnLocation.getY(),
+				spawnLocation.getZ() - spawnEntry.getZSize() / 2,
+				spawnLocation.getX() + spawnEntry.getXSize() / 2,
+				spawnLocation.getY() + spawnEntry.getYSize(),
+				spawnLocation.getZ() + spawnEntry.getZSize() / 2
+			)) {
 				return false;
 			}
 		} else {
-			if (!canSpawnMob(cave.getWorld(), spawnEntry,
-					spawnLocation.getX(), spawnLocation.getY(), spawnLocation.getZ(),
-					spawnLocation.getX() + 0.001, spawnLocation.getY() + 2, spawnLocation.getZ() + 0.001)) {
+			if (!canSpawnMob(
+				cave.getWorld(),
+				spawnEntry,
+				spawnLocation.getX(),
+				spawnLocation.getY(),
+				spawnLocation.getZ(),
+				spawnLocation.getX() + 0.001,
+				spawnLocation.getY() + 2,
+				spawnLocation.getZ() + 0.001
+			)) {
 				return false;
 			}
 		}
@@ -132,6 +147,7 @@ public class MobSpawnManager implements Runnable, Listener {
 				.map(OfflinePlayer::getPlayer)
 				.filter(player -> player != null && player.getWorld() == cave.getWorld())
 				.anyMatch(player -> player.getLocation().toVector().distanceSquared(spawnLocation) < spawnEntry.getMinDistance() * spawnEntry.getMinDistance())) {
+
 			return false;
 		}
 
@@ -146,7 +162,6 @@ public class MobSpawnManager implements Runnable, Listener {
 		Bukkit.getServer().getLogger().info("[Descent Mob Spawner]: Spawning " + spawnEntry.getName() + " for Player " + chosenPlayer.getName() + " in cave " + cave.getId());
 		
 		for(MobSpawnEntry t : cave.getStyle().getSpawnEntries()) {
-			
 			Bukkit.getServer().getLogger().info("Found MobSpawnEntry: " + t.getName() + " for cave style " + cave.getStyle().getName());
 		}
 
@@ -154,7 +169,7 @@ public class MobSpawnManager implements Runnable, Listener {
 	}
 
 	private boolean doSpawn(CaveTracker cave, MobSpawnEntry spawnEntry, UUID spawnedPlayer, Vector spawnLocation) {
-		boolean isMythicMob = MythicMobs.inst().getMobManager().getMythicMob(spawnEntry.getMob()) != null;
+		boolean isMythicMob = MythicBukkit.inst().getMobManager().getMythicMob(spawnEntry.getMob()).isPresent();
 		Location loc = spawnLocation.toLocation(cave.getWorld());
 
 		// spawn mob and check its hitbox doesn't intersect anything
@@ -165,7 +180,7 @@ public class MobSpawnManager implements Runnable, Listener {
 			currentSpawnEntry = spawnEntry;
 			ActiveMob activeMob;
 			try {
-				activeMob = MythicMobs.inst().getMobManager().spawnMob(spawnEntry.getMob(), loc);
+				activeMob = MythicBukkit.inst().getMobManager().spawnMob(spawnEntry.getMob(), loc);
 			} finally {
 				spawningMob = false;
 				currentSpawnEntry = null;

--- a/src/main/java/com/gmail/sharpcastle33/did/listeners/PacketListener.java
+++ b/src/main/java/com/gmail/sharpcastle33/did/listeners/PacketListener.java
@@ -151,7 +151,7 @@ public class PacketListener {
 		protocolManager.addPacketListener(new PacketAdapter(PacketAdapter.params(DescentIntoDarkness.instance, PacketType.Play.Server.RESPAWN, PacketType.Play.Server.LOGIN)) {
 			@Override
 			public void onPacketSending(PacketEvent event) {
-				event.getPacket().getModifier().withType(DIMENSION_TYPE).modify(0, dim -> {
+				event.getPacket().getModifier().withType(MinecraftReflection.getMinecraftClass("core.Holder")).modify(0, dim -> {
 					CaveTracker cave = DescentIntoDarkness.instance.getCaveTrackerManager().getCaveForPlayer(event.getPlayer());
 					if (cave != null) {
 						return cave.getStyle().isNether() ? NETHER_DIMENSION : END_DIMENSION;

--- a/src/main/java/com/gmail/sharpcastle33/did/listeners/PacketListener.java
+++ b/src/main/java/com/gmail/sharpcastle33/did/listeners/PacketListener.java
@@ -67,8 +67,8 @@ public class PacketListener {
 		PARTIAL_RESULT_MESSAGE = Accessors.getMethodAccessor(FuzzyReflection.fromClass(partialResultClass).getMethod(FuzzyMethodContract.newBuilder().nameExact("message").returnTypeExact(String.class).parameterCount(0).build()));
 
 		DIMENSION_TYPE = MinecraftReflection.getMinecraftClass("world.level.dimension.DimensionManager");
-		NETHER_DIMENSION = Accessors.getFieldAccessor(FuzzyReflection.fromClass(DIMENSION_TYPE, true).getFieldByName("q"), true).get(null);
-		END_DIMENSION = Accessors.getFieldAccessor(FuzzyReflection.fromClass(DIMENSION_TYPE, true).getFieldByName("r"), true).get(null);
+		NETHER_DIMENSION = Accessors.getFieldAccessor(FuzzyReflection.fromClass(DIMENSION_TYPE, true).getFieldByName("n"), true).get(null);
+		END_DIMENSION = Accessors.getFieldAccessor(FuzzyReflection.fromClass(DIMENSION_TYPE, true).getFieldByName("o"), true).get(null);
 	}
 
 	private static JsonObject registryManagerToJson(Object registryManager) {
@@ -152,7 +152,7 @@ public class PacketListener {
 		protocolManager.addPacketListener(new PacketAdapter(PacketAdapter.params(DescentIntoDarkness.instance, PacketType.Play.Server.RESPAWN, PacketType.Play.Server.LOGIN)) {
 			@Override
 			public void onPacketSending(PacketEvent event) {
-				event.getPacket().getModifier().withType(MinecraftReflection.getMinecraftClass("core.Holder")).modify(0, dim -> {
+				event.getPacket().getModifier().withType(MinecraftReflection.getMinecraftClass("resources.ResourceKey")).modify(0, dim -> {
 					CaveTracker cave = DescentIntoDarkness.instance.getCaveTrackerManager().getCaveForPlayer(event.getPlayer());
 					if (cave != null) {
 						return cave.getStyle().isNether() ? NETHER_DIMENSION : END_DIMENSION;

--- a/src/main/java/com/gmail/sharpcastle33/did/listeners/PacketListener.java
+++ b/src/main/java/com/gmail/sharpcastle33/did/listeners/PacketListener.java
@@ -131,20 +131,21 @@ public class PacketListener {
 		protocolManager.addPacketListener(new PacketAdapter(PacketAdapter.params(DescentIntoDarkness.instance, PacketType.Play.Server.MAP_CHUNK)) {
 			@Override
 			public void onPacketSending(PacketEvent event) {
-				event.getPacket().getIntegerArrays().modify(0, biomes -> {
-					if (biomes == null) {
-						return null;
-					}
-					if (!Biomes.isPlayerNotified(event.getPlayer().getUniqueId())) {
-						return biomes;
-					}
-					CaveTracker cave = DescentIntoDarkness.instance.getCaveTrackerManager().getCaveForPlayer(event.getPlayer());
-					if (cave == null) {
-						return biomes;
-					}
-					Arrays.fill(biomes, Biomes.getRawId(cave.getStyle().getBiome()));
-					return biomes;
-				});
+				// TODO: this event is broken by 1.18.2, and results in an error on chunk load. We need to figure out how to convert this into equivalent 1.18.2 code. This is the error we get: com.comphenix.protocol.reflect.FieldAccessException: No field with type [I exists in class ClientboundLevelChunkWithLightPacket.
+				// event.getPacket().getIntegerArrays().modify(0, biomes -> {
+				// 	if (biomes == null) {
+				// 		return null;
+				// 	}
+				// 	if (!Biomes.isPlayerNotified(event.getPlayer().getUniqueId())) {
+				// 		return biomes;
+				// 	}
+				// 	CaveTracker cave = DescentIntoDarkness.instance.getCaveTrackerManager().getCaveForPlayer(event.getPlayer());
+				// 	if (cave == null) {
+				// 		return biomes;
+				// 	}
+				// 	Arrays.fill(biomes, Biomes.getRawId(cave.getStyle().getBiome()));
+				// 	return biomes;
+				// });
 			}
 		});
 


### PR DESCRIPTION
### upgrade to MM 5

MythicMobs 4.0.8 doesn't seem to work with 1.18.2, and the MhthicMobs API has changed enough from v4 to v5 that code compiled under v4 won't run correctly under v5. For example, the v4 API is unable to spawn mobs against the v5 jar. I've upgraded our API from 4.0.8 to 5.0.3, and made the necessary changes to adapt to the new API.

### fix respawn/login listener

The respawn/login listener near the bottom of PacketListener.java was sending this error to the console every time a player logged in, respawned, joined a dimension, or left a dimension:

`com.comphenix.protocol.reflect.FieldAccessException: No field with type net.minecraft.world.level.dimension.DimensionManager exists in class PacketPlayOutRespawn`

A first fix attempt resolved this error in vanilla dimensions, but resulted in a casting error during custom dimension spawns:

`Cannot set field private final net.minecraft.resources.ResourceKey net.minecraft.network.protocol.game.PacketPlayOutLogin.h to value net.minecraft.world.level.dimension.DimensionManager@xxxxxxxx`

A second fix resolves this casting error, allowing MC to associate custom dimensions with either the end or the nether.

### comment out code that causes console spam

A map chunk loading listener, probably responsible for handling issues with overworld weather in conjunction with custom dimensions, was spamming the console with this error on every map chunk load:

`com.comphenix.protocol.reflect.FieldAccessException: No field with type [I exists in class ClientboundLevelChunkWithLightPacket.`

I found this to be very difficult to fix given my limited understanding of minecraft server programming. However, the console spam is pretty annoying, and could prevent other useful errors/warnings from being noticed. So for now, I've commented out the offending code and added a TODO comment above it.